### PR TITLE
resolution of some errors

### DIFF
--- a/Internal/package-authorization/Page.php
+++ b/Internal/package-authorization/Page.php
@@ -37,14 +37,14 @@ class Page extends PermissionExtends
      */
     public static function use($roleId = NULL, array $table = NULL, $callback = NULL)
     {
-        if( $roleId !== NULL && $table !== NULL )
-        {
-           return self::predefinedPermissionConfiguration($roleId, $table, $callback, 'page', [$roleId, NULL, NULL, 'page']);
-        }
-
         $realpath = self::$realpath;
 
         self::$realpath = NULL;
+
+        if( $roleId !== NULL && $table !== NULL )
+        {
+           return self::predefinedPermissionConfiguration($roleId, $table, $callback, 'page', [$roleId, NULL, NULL, 'page', $realpath]);
+        }
 
         return self::common(self::$roleId ?? $roleId, NULL, NULL, 'page', $realpath);
     }


### PR DESCRIPTION
[TR]
predefinedPermissionConfiguration metodu realpath parametresine erişemediğinden izin yapılandırması doğru çalışmıyor, ayrıca package-database/DB.php dosyasında 1912. satırda result[0] bulunamadığından hata logluyordu.

[EN]
The permission configuration did not work correctly because the predefinedPermissionConfiguration method could not access the realpath parameter, and also logged an error because result[0] was not found on line 1912 in the package-database/DB.php file.